### PR TITLE
make the "file" example work regardless of single or double quotes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ The following methods of extracting the version of a project are currently suppo
   .. code-block:: toml
 
     [tool.carthorse]
-    version-from = { name="file", path="setup.py", pattern="version='(?P<version>[^']+)" }
+    version-from = { name="file", path="setup.py", pattern="version=['\"](?P<version>[^'\"]+)" }
 
   .. invisible-code-block: python
 

--- a/conftest.py
+++ b/conftest.py
@@ -80,7 +80,7 @@ def repo(git: GitHelper) -> Path:
     repo = git.dir.as_path('local')
     (repo / 'pyproject.toml').write_text(serialize_toml({'tool': {'poetry': {'version': '1.0'}}}))
     (repo / 'foobar.py').write_text('__version__="2.0"\n')
-    (repo / 'setup.py').write_text("version='3.0'\n")
+    (repo / 'setup.py').write_text('version="3.0"\n')
     os.chdir(repo)
     return repo
 


### PR DESCRIPTION
Due to the popularity of [black](https://github.com/psf/black), I think many (most?) people will be using double quotes in `setup.py`